### PR TITLE
Moves application to Java 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Razorapay Test App for Java
+## Razorpay Test App for Java
 
 Sample app for Razorpay Java Integration
 
@@ -7,7 +7,7 @@ The sample app is made using [Dropwizard Framework](http://www.dropwizard.io/1.0
 # Steps to run sample app:
 
 - Edit the key inside index.ftl
-- Add you api_key and api_secret in server.yml file:
+- Add your api_key and api_secret in server.yml file:
 ```
 apiKey: your_api_key
 secretKey: your_api_secret

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,11 @@
   <artifactId>razorpay-java-testapp</artifactId>
   <version>1.0-SNAPSHOT</version>
 
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
   <dependencies>
 
     <dependency>


### PR DESCRIPTION
## Note :- Please follow the below points while attaching test cases document link below:
   ### - If label `Tested` is added then test cases document URL is mandatory.
   ### - Link added should be a valid URL and accessible throughout the org.
   ### - If the branch name contains hotfix / revert by default the BVT workflow check will pass.

| Test Case Document URL                        |
|-----------------------------------------------|
|  ![Server Logs](https://github.com/razorpay/razorpay-java-testapp/assets/38849757/33d4b5cb-4280-4a79-b6d2-04a8584f6055) |

`mvn clean install` logs:

```
➜  razorpay-java-testapp git:(master) ✗ mvn clean install
[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------< com.razorpay:razorpay-java-testapp >-----------------
[INFO] Building razorpay-java-testapp 1.0-SNAPSHOT
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ razorpay-java-testapp ---
[INFO] Deleting /home/pradipta/projects/razorpay-java-testapp/target
[INFO] 
[INFO] --- maven-resources-plugin:2.6:resources (default-resources) @ razorpay-java-testapp ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] Copying 2 resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.6.0:compile (default-compile) @ razorpay-java-testapp ---
[INFO] Changes detected - recompiling the module!
[WARNING] File encoding has not been set, using platform encoding UTF-8, i.e. build is platform dependent!
[INFO] Compiling 5 source files to /home/pradipta/projects/razorpay-java-testapp/target/classes
[INFO] /home/pradipta/projects/razorpay-java-testapp/src/main/java/com/razorpay/App.java: /home/pradipta/projects/razorpay-java-testapp/src/main/java/com/razorpay/App.java uses unchecked or unsafe operations.
[INFO] /home/pradipta/projects/razorpay-java-testapp/src/main/java/com/razorpay/App.java: Recompile with -Xlint:unchecked for details.
[INFO] 
[INFO] --- maven-resources-plugin:2.6:testResources (default-testResources) @ razorpay-java-testapp ---
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
[INFO] skip non existing resourceDirectory /home/pradipta/projects/razorpay-java-testapp/src/test/resources
[INFO] 
[INFO] --- maven-compiler-plugin:3.6.0:testCompile (default-testCompile) @ razorpay-java-testapp ---
[INFO] No sources to compile
[INFO] 
[INFO] --- maven-surefire-plugin:2.12.4:test (default-test) @ razorpay-java-testapp ---
[INFO] No tests to run.
[INFO] 
[INFO] --- maven-jar-plugin:2.4:jar (default-jar) @ razorpay-java-testapp ---
[INFO] Building jar: /home/pradipta/projects/razorpay-java-testapp/target/razorpay-java-testapp-1.0-SNAPSHOT.jar
[INFO] 
[INFO] --- maven-shade-plugin:1.6:shade (default) @ razorpay-java-testapp ---
[INFO] Including io.dropwizard:dropwizard-core:jar:1.0.2 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-util:jar:1.0.2 in the shaded jar.
[INFO] Including com.fasterxml.jackson.core:jackson-annotations:jar:2.7.6 in the shaded jar.
[INFO] Including com.google.guava:guava:jar:19.0 in the shaded jar.
[INFO] Including com.google.code.findbugs:jsr305:jar:3.0.1 in the shaded jar.
[INFO] Including joda-time:joda-time:jar:2.9.4 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-jackson:jar:1.0.2 in the shaded jar.
[INFO] Including com.fasterxml.jackson.core:jackson-core:jar:2.7.6 in the shaded jar.
[INFO] Including com.fasterxml.jackson.core:jackson-databind:jar:2.7.6 in the shaded jar.
[INFO] Including com.fasterxml.jackson.datatype:jackson-datatype-guava:jar:2.7.6 in the shaded jar.
[INFO] Including com.fasterxml.jackson.datatype:jackson-datatype-jsr310:jar:2.7.6 in the shaded jar.
[INFO] Including com.fasterxml.jackson.datatype:jackson-datatype-jdk8:jar:2.7.6 in the shaded jar.
[INFO] Including com.fasterxml.jackson.module:jackson-module-afterburner:jar:2.7.6 in the shaded jar.
[INFO] Including com.fasterxml.jackson.datatype:jackson-datatype-joda:jar:2.7.6 in the shaded jar.
[INFO] Including org.slf4j:slf4j-api:jar:1.7.21 in the shaded jar.
[INFO] Including ch.qos.logback:logback-classic:jar:1.1.7 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-validation:jar:1.0.2 in the shaded jar.
[INFO] Including org.hibernate:hibernate-validator:jar:5.2.4.Final in the shaded jar.
[INFO] Including javax.validation:validation-api:jar:1.1.0.Final in the shaded jar.
[INFO] Including org.jboss.logging:jboss-logging:jar:3.2.1.Final in the shaded jar.
[INFO] Including com.fasterxml:classmate:jar:1.1.0 in the shaded jar.
[INFO] Including org.glassfish:javax.el:jar:3.0.0 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-configuration:jar:1.0.2 in the shaded jar.
[INFO] Including com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:jar:2.7.6 in the shaded jar.
[INFO] Including org.yaml:snakeyaml:jar:1.15 in the shaded jar.
[INFO] Including org.apache.commons:commons-lang3:jar:3.4 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-logging:jar:1.0.2 in the shaded jar.
[INFO] Including io.dropwizard.metrics:metrics-logback:jar:3.1.2 in the shaded jar.
[INFO] Including org.slf4j:jul-to-slf4j:jar:1.7.21 in the shaded jar.
[INFO] Including ch.qos.logback:logback-core:jar:1.1.7 in the shaded jar.
[INFO] Including org.slf4j:log4j-over-slf4j:jar:1.7.21 in the shaded jar.
[INFO] Including org.slf4j:jcl-over-slf4j:jar:1.7.21 in the shaded jar.
[INFO] Including org.eclipse.jetty:jetty-util:jar:9.3.9.v20160517 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-metrics:jar:1.0.2 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-jersey:jar:1.0.2 in the shaded jar.
[INFO] Including org.glassfish.jersey.core:jersey-server:jar:2.23.1 in the shaded jar.
[INFO] Including org.glassfish.jersey.core:jersey-common:jar:2.23.1 in the shaded jar.
[INFO] Including org.glassfish.jersey.bundles.repackaged:jersey-guava:jar:2.23.1 in the shaded jar.
[INFO] Including org.glassfish.hk2:osgi-resource-locator:jar:1.0.1 in the shaded jar.
[INFO] Including org.glassfish.jersey.core:jersey-client:jar:2.23.1 in the shaded jar.
[INFO] Including javax.ws.rs:javax.ws.rs-api:jar:2.0.1 in the shaded jar.
[INFO] Including org.glassfish.jersey.media:jersey-media-jaxb:jar:2.23.1 in the shaded jar.
[INFO] Including javax.annotation:javax.annotation-api:jar:1.2 in the shaded jar.
[INFO] Including org.glassfish.hk2:hk2-api:jar:2.4.0-b34 in the shaded jar.
[INFO] Including org.glassfish.hk2:hk2-utils:jar:2.4.0-b34 in the shaded jar.
[INFO] Including org.glassfish.hk2.external:aopalliance-repackaged:jar:2.4.0-b34 in the shaded jar.
[INFO] Including org.glassfish.hk2.external:javax.inject:jar:2.4.0-b34 in the shaded jar.
[INFO] Including org.glassfish.hk2:hk2-locator:jar:2.4.0-b34 in the shaded jar.
[INFO] Including org.javassist:javassist:jar:3.18.1-GA in the shaded jar.
[INFO] Including org.glassfish.jersey.ext:jersey-metainf-services:jar:2.23.1 in the shaded jar.
[INFO] Including org.glassfish.jersey.ext:jersey-bean-validation:jar:2.23.1 in the shaded jar.
[INFO] Including io.dropwizard.metrics:metrics-jersey2:jar:3.1.2 in the shaded jar.
[INFO] Including com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:jar:2.7.6 in the shaded jar.
[INFO] Including com.fasterxml.jackson.jaxrs:jackson-jaxrs-base:jar:2.7.6 in the shaded jar.
[INFO] Including com.fasterxml.jackson.module:jackson-module-jaxb-annotations:jar:2.7.6 in the shaded jar.
[INFO] Including org.glassfish.jersey.containers:jersey-container-servlet:jar:2.23.1 in the shaded jar.
[INFO] Including org.glassfish.jersey.containers:jersey-container-servlet-core:jar:2.23.1 in the shaded jar.
[INFO] Including org.eclipse.jetty:jetty-server:jar:9.3.9.v20160517 in the shaded jar.
[INFO] Including javax.servlet:javax.servlet-api:jar:3.1.0 in the shaded jar.
[INFO] Including org.eclipse.jetty:jetty-io:jar:9.3.9.v20160517 in the shaded jar.
[INFO] Including org.eclipse.jetty:jetty-webapp:jar:9.3.9.v20160517 in the shaded jar.
[INFO] Including org.eclipse.jetty:jetty-xml:jar:9.3.9.v20160517 in the shaded jar.
[INFO] Including org.eclipse.jetty:jetty-continuation:jar:9.3.9.v20160517 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-servlets:jar:1.0.2 in the shaded jar.
[INFO] Including io.dropwizard.metrics:metrics-annotation:jar:3.1.2 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-jetty:jar:1.0.2 in the shaded jar.
[INFO] Including io.dropwizard.metrics:metrics-jetty9:jar:3.1.2 in the shaded jar.
[INFO] Including org.eclipse.jetty:jetty-servlet:jar:9.3.9.v20160517 in the shaded jar.
[INFO] Including org.eclipse.jetty:jetty-security:jar:9.3.9.v20160517 in the shaded jar.
[INFO] Including org.eclipse.jetty:jetty-servlets:jar:9.3.9.v20160517 in the shaded jar.
[INFO] Including org.eclipse.jetty:jetty-http:jar:9.3.9.v20160517 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-lifecycle:jar:1.0.2 in the shaded jar.
[INFO] Including io.dropwizard.metrics:metrics-core:jar:3.1.2 in the shaded jar.
[INFO] Including io.dropwizard.metrics:metrics-jvm:jar:3.1.2 in the shaded jar.
[INFO] Including io.dropwizard.metrics:metrics-servlets:jar:3.1.2 in the shaded jar.
[INFO] Including io.dropwizard.metrics:metrics-json:jar:3.1.2 in the shaded jar.
[INFO] Including io.dropwizard.metrics:metrics-healthchecks:jar:3.1.2 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-request-logging:jar:1.0.2 in the shaded jar.
[INFO] Including ch.qos.logback:logback-access:jar:1.1.7 in the shaded jar.
[INFO] Including net.sourceforge.argparse4j:argparse4j:jar:0.7.0 in the shaded jar.
[INFO] Including org.eclipse.jetty.toolchain.setuid:jetty-setuid-java:jar:1.0.3 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-views:jar:1.0.2 in the shaded jar.
[INFO] Including io.dropwizard:dropwizard-views-freemarker:jar:1.0.2 in the shaded jar.
[INFO] Including org.freemarker:freemarker:jar:2.3.23 in the shaded jar.
[INFO] Including com.razorpay:razorpay-java:jar:1.3.1 in the shaded jar.
[INFO] Including com.squareup.okhttp3:okhttp:jar:3.4.1 in the shaded jar.
[INFO] Including com.squareup.okio:okio:jar:1.9.0 in the shaded jar.
[INFO] Including com.squareup.okhttp3:logging-interceptor:jar:3.4.1 in the shaded jar.
[INFO] Including org.json:json:jar:20160212 in the shaded jar.
[INFO] Including commons-codec:commons-codec:jar:1.4 in the shaded jar.
[INFO] Replacing original artifact with shaded artifact.
[INFO] Replacing /home/pradipta/projects/razorpay-java-testapp/target/razorpay-java-testapp-1.0-SNAPSHOT.jar with /home/pradipta/projects/razorpay-java-testapp/target/razorpay-java-testapp-1.0-SNAPSHOT-shaded.jar
[INFO] 
[INFO] --- maven-install-plugin:2.4:install (default-install) @ razorpay-java-testapp ---
[INFO] Installing /home/pradipta/projects/razorpay-java-testapp/target/razorpay-java-testapp-1.0-SNAPSHOT.jar to /home/pradipta/.m2/repository/com/razorpay/razorpay-java-testapp/1.0-SNAPSHOT/razorpay-java-testapp-1.0-SNAPSHOT.jar
[INFO] Installing /home/pradipta/projects/razorpay-java-testapp/dependency-reduced-pom.xml to /home/pradipta/.m2/repository/com/razorpay/razorpay-java-testapp/1.0-SNAPSHOT/razorpay-java-testapp-1.0-SNAPSHOT.pom
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  6.116 s
[INFO] Finished at: 2023-10-17T18:58:39+05:30
[INFO] ------------------------------------------------------------------------

```